### PR TITLE
Fix Mapper3 chr bank

### DIFF
--- a/src/rom.rs
+++ b/src/rom.rs
@@ -129,7 +129,7 @@ impl RomHeader {
 		self.load(4)
 	}
 
-	fn chr_rom_bank_num(&self) -> u8 {
+	pub fn chr_rom_bank_num(&self) -> u8 {
 		self.load(5)
 	}
 


### PR DESCRIPTION
I couldn't find in the specification but it seems that we need to wrap with 8k character bank size for MMC3Mapper chr bank selection.