### PR TITLE
Do not reset sequence index of APU triangle unit when writing to 0x400B

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -605,7 +605,6 @@ impl ApuTriangle {
 					self.length_counter = LENGTH_TABLE[self.length_counter_index() as usize];
 				}
 
-				self.timer_sequence = 0;
 				self.linear_reload_flag = true;
 			},
 			_ => {} // @TODO: Throw an error?


### PR DESCRIPTION
It seems we shouldn't reset sequence index of APU triangle unit when writing to 0x400B. With this change, triangle will have less noise.